### PR TITLE
Create ota_cfg_Moto G (5)_reteu_Blur_Version.25.351.21.cedric.retail.en.US

### DIFF
--- a/cfg/ota_cfg_Moto G (5)_reteu_Blur_Version.25.351.21.cedric.retail.en.US
+++ b/cfg/ota_cfg_Moto G (5)_reteu_Blur_Version.25.351.21.cedric.retail.en.US
@@ -1,0 +1,6 @@
+[OTA_UPDATE_CFG]
+MODEL=Moto G (5)
+CARRIER=reteu
+SV=Blur_Version.25.351.21.cedric.retail.en.US
+SN=
+RS=


### PR DESCRIPTION
Add Moto G(5)
---------------
Version: Blur_Version.28.41.12.cedric.retail.en.US
Display Version: OPP28.85-13
Install time: 30 min.
Update size: 1.10GB