### PR TITLE
Create ota_cfg_Moto G (5)_retin_Blur_Version_25.351.21.cedric.retail.en.US

### DIFF
--- a/cfg/ota_cfg_Moto G (5)_retin_Blur_Version_25.351.21.cedric.retail.en.US
+++ b/cfg/ota_cfg_Moto G (5)_retin_Blur_Version_25.351.21.cedric.retail.en.US
@@ -1,0 +1,6 @@
+[OTA_UPDATE_CFG]
+MODEL=Moto G (5)
+CARRIER=retin
+SV=Blur_Version.25.351.21.cedric.retail.en.US
+SN=
+RS=


### PR DESCRIPTION
Add Moto G(5) retin
--------------------
Version: Blur_Version:28.41.15.cedric.retail.en.US
Display Version: OPP28.85-16
Install time: 30 min.
Update size: 1.10GB